### PR TITLE
Add about:home and about:preferences to privileged URLs list.

### DIFF
--- a/background.js
+++ b/background.js
@@ -47,10 +47,12 @@ const isPrivilegedURL = function(url) {
   return url == 'about:config' ||
     url == 'about:debugging' ||
     url == 'about:addons' ||
+    url == 'about:home' ||
     url.startsWith('chrome:') ||
     url.startsWith('javascript:') ||
     url.startsWith('data:') ||
     url.startsWith('file:') ||
+    url.startsWith('about:preferences') ||
     url.startsWith('about:config');
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Sticky Containers",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "David Lynch",
 
   "description": "New tabs will keep the current container",


### PR DESCRIPTION
Fixes this:
![demo](https://user-images.githubusercontent.com/49518157/85272719-c15eae80-b4a6-11ea-8423-21b882a051d7.gif)
(Preference and new window closing immediately upon open)
