### PR TITLE
Add two shortcuts: open new tab in same container and open new tab without container. Also improve privileged URLs recognition.

### DIFF
--- a/background.js
+++ b/background.js
@@ -46,6 +46,7 @@ const updateLastCookieStoreId = function(tab) {
 const isPrivilegedURL = function(url) {
   return url == 'about:config' ||
     url == 'about:debugging' ||
+    url == 'about:blank' ||
     url == 'about:addons' ||
     url == 'about:home' ||
     url.startsWith('chrome:') ||
@@ -120,6 +121,15 @@ browser.commands.onCommand.addListener(function(command) {
     const tabProperties = {
 	  active: true,
 	  cookieStoreId: lastCookieStoreId,
+    };
+    browser.tabs.create(tabProperties);
+  }
+  else if (command == "open-new-tab-without-container") {
+    console.debug("opening a new tab without container");
+    lastCookieStoreId = defaultCookieStoreId;
+    const tabProperties = {
+      active: true,
+      cookieStoreId: defaultCookieStoreId,
     };
     browser.tabs.create(tabProperties);
   }

--- a/background.js
+++ b/background.js
@@ -114,6 +114,17 @@ browser.windows.onFocusChanged.addListener(windowId => {
   }
 });
 
+browser.commands.onCommand.addListener(function(command) {
+  if (command == "open-new-tab-in-same-container") {
+    console.debug("opening a new tab in container", lastCookieStoreId);
+    const tabProperties = {
+	  active: true,
+	  cookieStoreId: lastCookieStoreId,
+    };
+    browser.tabs.create(tabProperties);
+  }
+});
+
 // DEBUG help for me later:
 /*
 browser.tabs.onCreated.addListener(tab => {

--- a/background.js
+++ b/background.js
@@ -44,17 +44,11 @@ const updateLastCookieStoreId = function(tab) {
 };
 
 const isPrivilegedURL = function(url) {
-  return url == 'about:config' ||
-    url == 'about:debugging' ||
-    url == 'about:blank' ||
-    url == 'about:addons' ||
-    url == 'about:home' ||
+  return url.startsWith('about:') ||
     url.startsWith('chrome:') ||
     url.startsWith('javascript:') ||
     url.startsWith('data:') ||
-    url.startsWith('file:') ||
-    url.startsWith('about:preferences') ||
-    url.startsWith('about:config');
+    url.startsWith('file:');
 }
 
 // Event flow is:

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Sticky Containers",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "David Lynch",
 
   "description": "New tabs will keep the current container",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Sticky Containers",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "David Lynch",
 
   "description": "New tabs will keep the current container",
@@ -20,6 +20,12 @@
 		"default": "Ctrl+Y"
 	  },
 	  "description": "Open a new tab in the same container as the current one"
+    },
+    "open-new-tab-without-container": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+Y"
+      },
+      "description": "Open a new tab without any container"
     }
   },
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Sticky Containers",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "author": "David Lynch",
 
   "description": "New tabs will keep the current container",
@@ -13,6 +13,14 @@
 
   "background": {
     "scripts": ["background.js"]
+  },
+  "commands": {
+  	"open-new-tab-in-same-container": {
+	  "suggested_key": {
+		"default": "Ctrl+Y"
+	  },
+	  "description": "Open a new tab in the same container as the current one"
+    }
   },
   "permissions": [
     "<all_urls>",


### PR DESCRIPTION
**Ctrl+Y to open a new tab in the same container as the current one**
The tab opens directly into that container (as opposed to only switching to that container onBeforeNavigate), so you get the right color in the tab bar. It's a shame we can't rewire Ctrl+T or the new tab button.

**Ctrl+Alt+Y to open a new tab without any container**
Open a new tab without any container. This allows 'escaping' the container stickiness. 

I also changed isPrivilegedUrl to catch all about: URLs. This fixes the issue with pressing Customize (in the hamburger menu) when inside a container. 




Sorry about the jumping version number.